### PR TITLE
Gets specs passing locally (and on Travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 2.0.0
+  - 2.6.3
+  - 2.5.3
 script: 'bundle exec rspec --tag ~not_on_travis'

--- a/spec/sony_ci_api_spec.rb
+++ b/spec/sony_ci_api_spec.rb
@@ -159,7 +159,7 @@ describe 'Sony Ci API' do
       expect(after - middle).to be < 0.01
       expect(middle - before).to be > 0.1 # Often greater than 1
 
-      expect(download_url).to match(%r{^https://.*cloudfront.net\/cifiles})
+      expect(download_url).to match(%r{^https://.*cdn01.cimediacloud.com\/cifiles})
       if File.new(path).size < 1024
         curl = Curl::Easy.http_get(download_url)
         curl.perform
@@ -196,6 +196,7 @@ describe 'Sony Ci API' do
     end
 
     before(:each) do
+      WebMock.enable!
       WebMock.disable_net_connect!
 
       stub_request(:post, "https://api.cimediacloud.com/oauth2/token")


### PR DESCRIPTION
Currently, the specs rely on a valid test workspace in Sony Ci. I hope to change
that soon, but for now, that's the deal.